### PR TITLE
Quicker setting of email address

### DIFF
--- a/Major Key/ViewController.swift
+++ b/Major Key/ViewController.swift
@@ -147,6 +147,8 @@ class ViewController: UIViewController, UITextViewDelegate {
         
         alert.addTextField { (textField) in
             textField.placeholder = "Your email address"
+            textField.keyboardType = .emailAddress
+            textField.textContentType = UITextContentType.emailAddress
         }
         
         alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { [weak alert] (_) in


### PR DESCRIPTION
When adding/updating the "send to" email address, the alert view now has
- an email friendly keyboard
- auto suggests common email address

**From this**
![slow-gif-resize](https://user-images.githubusercontent.com/939454/45390729-33d70500-b618-11e8-8cbd-26a513703d33.gif)

**To this**
![quick-gif](https://user-images.githubusercontent.com/939454/45390793-684ac100-b618-11e8-8aed-3a1425204227.gif)

