### PR TITLE
Dispatch to main after API call for UI interaction

### DIFF
--- a/Major Key/ViewController.swift
+++ b/Major Key/ViewController.swift
@@ -114,24 +114,24 @@ class ViewController: UIViewController, UITextViewDelegate {
             // Request body
             request.httpBody = postString //postString.data(using: .utf8)
             let task = URLSession.shared.dataTask(with: request) { data, response, error in
-                guard let data = data, error == nil else {                                                 // check for fundamental networking error
-                    print("error=\(String(describing: error))")
-                    self.showAlert(title: "Error", body: String(describing: error), theme: .error);
-                    return
-                }
-                
-                if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode != 200 {           // check for http errors
-                    print("statusCode should be 200, but is \(httpStatus.statusCode)")
-                    print("response = \(String(describing: response) )")
-                    self.showAlert(title: "Error", body: String(describing: response), theme: .error);
-                    return
-                }
-                
-                let responseString = String(data: data, encoding: .utf8)
-                print("responseString = \(String(describing: responseString))")
-                self.showAlert(title: "Major Key", body: "Never forget dat major key", theme: .success);
-                
                 DispatchQueue.main.async {
+                    guard let data = data, error == nil else {                                                 // check for fundamental networking error
+                        print("error=\(String(describing: error))")
+                        self.showAlert(title: "Error", body: String(describing: error), theme: .error);
+                        return
+                    }
+
+                    if let httpStatus = response as? HTTPURLResponse, httpStatus.statusCode != 200 {           // check for http errors
+                        print("statusCode should be 200, but is \(httpStatus.statusCode)")
+                        print("response = \(String(describing: response) )")
+                        self.showAlert(title: "Error", body: String(describing: response), theme: .error);
+                        return
+                    }
+
+                    let responseString = String(data: data, encoding: .utf8)
+                    print("responseString = \(String(describing: responseString))")
+                    self.showAlert(title: "Major Key", body: "Never forget dat major key", theme: .success);
+
                     self.majorTextView.text = ""
                 }
             }


### PR DESCRIPTION
We should dispatch to main after the API call to handle all UI interactions on the main thread. Currently if an error occurs it will call `showAlert` on a background thread.

I don't think we need to dispatch to main on each UI call as we are not really doing so much work within the callback handler so I would recommend to just dispatch it immediately.